### PR TITLE
SPEC 7: Language adjustments and decorator code generalization

### DIFF
--- a/spec-0007/index.md
+++ b/spec-0007/index.md
@@ -5,6 +5,7 @@ author:
   - "Stéfan van der Walt <stefanv@berkeley.edu>"
   - "Sebastian Berg <sebastianb@nvidia.com>"
   - "Pamphile Roy <roy.pamphile@gmail.com>"
+  - "Matt Haberland <mhaberla@calpoly.edu>"
   - Other participants in the discussion <not.yet@named.org>"
 discussion: https://github.com/scipy/scipy/issues/14322
 endorsed-by:
@@ -12,30 +13,24 @@ endorsed-by:
 
 ## Description
 
-<!--
-Briefly and clearly describe the proposal.
-Explain the general need and the advantages of this specific proposal.
-If relevant, include examples of how the new functionality would be used,
-intended use-cases, and pseudo-code illustrating its use.
--->
-
-There is disparity in the APIs libraries provide to seed random number generation.
-This SPEC suggests a single, pragmatic API for the ecosystem, taking into account technical and historical factors.
+Currently, libraries across the ecosystem provide various APIs for seeding random number generation.
+This SPEC suggests a unified, pragmatic API, taking into account technical and historical factors.
 Adopting such a uniform API will simplify the user experience, especially for those who rely on multiple projects.
 
-We recommend to:
+We recommend:
 
-- Standardize the usage and interpretation of an `rng` keyword for seeding, and
-- avoid the use of global state and legacy bitstream generators.
+- avoiding the use of global state and legacy bitstream generators, and
+- standardizing the usage and interpretation of an `rng` keyword for seeding.
 
-We suggest doing this by:
+We suggest implementing these principles by:
 
-- Passing the `rng` argument to `numpy.random.default_rng` to instantiate a `Generator`, and
-- deprecating the use of `np.seed` and `RandomState`.
+- deprecating the use of `RandomState` and `numpy.random.seed`,
+- accepting an `rng` argument in all functions that require random number generation, and
+- using `numpy.random.default_rng` to validate the `rng` argument and instantiate a `Generator`.
 
 ### Concepts
 
-- `BitGenerator`: Generates a stream of pseudo-random bits. The default generator in NumPy (`np.random.default_rng`) uses PCG64.
+- `BitGenerator`: Generates a stream of pseudo-random bits. The default generator in NumPy (`numpy.random.default_rng`) uses PCG64.
 - `Generator`: Derives pseudo-random numbers from the bits produced by a `BitGenerator`.
 - `RandomState`: a [legacy object in NumPy](https://numpy.org/doc/stable/reference/random/index.html), similar to `Generator`, that produces random numbers based on the Mersenne Twister.
 
@@ -43,31 +38,27 @@ We suggest doing this by:
 
 NumPy, SciPy, scikit-learn, scikit-image, and NetworkX all implement pseudo-random seeding in slightly different ways.
 Common keyword arguments include `random_state` and `seed`.
-In practice, the seed is unfortunately also often controlled using `np.random.seed`.
+In practice, the seed is unfortunately also often controlled using `numpy.random.seed`.
 
 ## Implementation
-
-<!--
-Discuss how this would be implemented.
--->
 
 Legacy behavior in packages such as scikit-learn (`sklearn.utils.check_random_state`) typically handle `None` (use the global seed state), an int (convert to `RandomState`), or `RandomState` object.
 
 Two strong motivations for moving over to `Generator`s are:
 
 (1) they avoid naïve seeding strategies, such as using successive integers, via the underlying [SeedSequence](https://numpy.org/doc/stable/reference/random/parallel.html#seedsequence-spawning);
-(2) they avoid using global state (from `np.random.mtrand._rand`).
+(2) they avoid using global state (from `numpy.random.mtrand._rand`).
 
 Our recommendation here is a deprecation strategy which does not in _all_ cases adhere to the Hinsen[^hinsen] principle.
 
 The [deprecation strategy](https://github.com/scientific-python/specs/pull/180#issuecomment-1515248009) is:
 
-1. Accept both `rng` and `random_state` keyword arguments.
-2. If `rng=None`, handle `random_state` as in legacy behavior (see above), except use a compatible Generator instead of RandomState.
+1. Accept both `rng` and `random_state`/`seed` keyword arguments.
+2. If `rng=None`, handle `random_state`/`seed` as in legacy behavior (see above), except use a compatible Generator instead of RandomState.
    A DeprecationWarning is raised to warn about a future change in behavior.
-3. After <X time>, use only `rng`, seeding with `default_rng(rng)`.
-   Raise an error if `random_state` is provided.
-4. At a time of the library's choosing, remove any machinery related to `random_state`.
+3. After <X time>, use only `rng` validated with `numpy.random.default_rng`.
+   Raise an error if `random_state`/`seed` is provided.
+4. At a time of the library's choosing, remove any machinery related to `random_state`/`seed`.
 
    By now, the function signature, with type annotations, could look like this:
 
@@ -97,29 +88,29 @@ The [deprecation strategy](https://github.com/scientific-python/specs/pull/180#i
 
    ```
 
-   Also note the suggested language for the `rng` parameter docstring.
+   Also note the suggested language for the `rng` parameter docstring, which encourages the user to pass a `Generator` or None, but allows for other types accepted by `numpy.random.default_rng`.
 
 ### Impact
 
 The following users will be affected:
 
-1. Those who use `np.random.seed`.
+1. Those who use `numpy.random.seed`. 
    The proposal will do away with that global seeding mechanism, meaning that code that relies on it will, after a certain deprecation period, start seeing a different stream of random numbers than before.
-   To ensure that this does not go unnoticed, the library should raise a `FutureWarning` if `np.random.seed` was called earlier (we show how to do that further down).
+   To ensure that this does not go unnoticed, the library should raise a `FutureWarning` if `np.random.seed` has been called. (See Code below for an example.)
 
-   Code will, in effect, go from being seeded to being unseeded. To avoid that from happening, users should switch from using `np.random.seed` to specifying the `rng` argument to all functions that allow it.
+   Such code will, in effect, go from being seeded to being unseeded. 
+   To prevent this, users must switch from using `numpy.random.seed` to passing the `rng` argument explicitly to all functions that accept it.
 
 2. Those who do not seed. Their code will, after the deprecation period, use the newly proposed default. Since they were already not requesting repeatable sequences, and since the underlying _distributions_ of pseudo-random numbers did not change, they should be unaffected.
 
-3. Users of `random_state=...`.
-   Support for the `random_state` argument may be dropped eventually, at which point using that keyword will raise an error.
-   Meanwhile we can provide clear guidance, via deprecation warnings and documentation, on how to migrate to the new `rng` keyword.
+3. Users of `random_state`/`seed` arguments. 
+   Support for these arguments will be dropped eventually, but during the deprecation period, we can provide clear guidance, via warnings and documentation, on how to migrate to the new `rng` keyword.
 
 [^hinsen]: The Hinsen principle states, loosely, that code should, whether executed now or in the future, return the same result, or raise an error.
 
 ### Code
 
-As an example, consider how SciPy would transition from the `seed` to the `rng` keyword using a decorator.
+As an example, consider how a SciPy function would transition from a `seed` parameter to the `rng` keyword using a decorator.
 This is implemented using:
 
 1. A `check_random_state` function which normalizes either old (`seed`) or new (`rng`) input to a `Generator` object.
@@ -129,12 +120,37 @@ This is implemented using:
    It changes the documentation and auto-completion to only advertise the new `rng` parameter.
 
 ```python
+import numpy as np
+import functools
+import numbers
+import warnings
+
 _NoValue = object()  # singleton to indicate not explicitly passed
 
-
-def check_random_state(seed=_NoValue, rng=_NoValue):
+# Should this specify the version number in which the behavior will change?
+def _check_random_state(seed=_NoValue, rng=_NoValue):
+    """ PRNG validator during deprecation period
+    
+    Accepts inputs specified via old `seed` (or `random_state`) arguments
+    or new `rng` argument and returns appropriate PRNG.
+    
+    Once the removal of `seed`/`random_state` argument is executed,
+    this function may be removed, and `numpy.random.default_rng` may be
+    used to validate the `rng` argument.
+    
+    Parameters
+    ----------
+    seed : <insert long list of objects here>
+        Input specified via old `seed` (or `random_state`) argument
+    rng :  <insert long list of objects here>
+        Input specified via old `seed` (or `random_state`) argument
+    Returns
+    -------
+    prng : NumPy `Generator` or `RandomState`
+        Pseudo-random number generator
+    """
     if rng is not _NoValue and seed is not _NoValue:
-        raise TypeError("cannot pass both `rng=` and `random_state=` at the same time.")
+        raise TypeError("Cannot pass both `rng` and `seed` (or `random_state`).")
     if rng is not _NoValue:
         return np.random.default_rng(rng)
 
@@ -161,62 +177,106 @@ def check_random_state(seed=_NoValue, rng=_NoValue):
         return seed
 
     raise ValueError(f"'{seed}' cannot be used to seed a numpy.random.RandomState"
-                     " instance")
+                     " instance.")
 
 
-def _prepare_rng(old_name, dep_version=None):
+def _prepare_rng(old_name, position_num=None, dep_version=None):
+    """ Example decorator to deprecate old PRNG usage
+
+    Parameters
+    ----------
+    old_name : str
+        The old name of the PRNG argument (e.g. `seed` or `random_state`).
+    position_num : int, optional
+        The (0-indexed) position of the old PRNG argument (if accepted by position).
+        Maintainers are welcome to eliminate this argument and use, for example,
+        `inspect`, if preferred.
+    dep_version : str, optional
+        The full version number of the library in which positional and kwarg use
+        of the old PRNG argument was deprecated. If specified, `DeprecationWarning`s
+        will be emitted.
+
+    """
     new_name = "rng"
+
+    if dep_version:
+        end_version = dep_version.split('.')
+        end_version[1] = str(int(end_version[1]) + 2)
+        end_version = '.'.join(end_version)
 
     def decorator(fun):
         @functools.wraps(fun)
         def wrapper(*args, **kwargs):
-            if old_name in kwargs:
+            # Determine how PRNG was passed
+            as_old_kwarg = old_name in kwargs
+            as_new_kwarg = new_name in kwargs
+            as_pos_arg = position_num is not None and len(args) >= position_num + 1
+            
+            # Can only specify PRNG one way
+            if int(as_old_kwarg) + int(as_new_kwarg) + int(as_pos_arg) > 1:
+                message = (f"{fun.__name__}() got multiple values for "
+                           f"argument now known as `{new_name}`")
+                raise TypeError(message)
+            
+            if as_old_kwarg:  # warn about deprecated use of old kwarg
+                kwargs[new_name] = _check_random_state(seed=kwargs.pop(old_name))
                 if dep_version:
-                    end_version = dep_version.split('.')
-                    end_version[1] = str(int(end_version[1]) + 2)
-                    end_version = '.'.join(end_version)
                     message = (f"Use of keyword argument `{old_name}` is "
                                f"deprecated and replaced by `{new_name}`.  "
                                f"Support for `{old_name}` will be removed "
                                f"in SciPy {end_version}.")
                     warnings.warn(message, DeprecationWarning, stacklevel=2)
-                if new_name in kwargs:
-                    message = (f"{fun.__name__}() got multiple values for "
-                               f"argument now known as `{new_name}`")
-                    raise TypeError(message)
 
-            kwargs[new_name] = check_random_state(
-                kwargs.pop(old_name, _NoValue),
-                rng=kwargs.pop(new_name, _NoValue)
-            )
+            elif as_pos_arg:  # warn about deprecated positional use
+                # Not required for adoption of this SPEC; feel free to remove
+                args = list(args)
+                args[position_num] = _check_random_state(seed=args[position_num])
+                if dep_version:
+                    message = (f"Positional use of argument `{old_name}` and "
+                               "those that follow is deprecated and will cause "
+                               f"an error in SciPy {end_version}. Replace these "
+                               f"with keyword arguments, and use `{new_name}` "
+                               f"instead of `{old_name}`.")
+                    warnings.warn(message, DeprecationWarning, stacklevel=2)
+
+            elif as_new_kwarg:  # no warnings; this is the preferred use
+                kwargs[new_name] = _check_random_state(rng=kwargs[new_name])
+
+            else:  # will emit FutureWarning if `np.random.seed` was used
+                kwargs[new_name] = _check_random_state()
+
             return fun(*args, **kwargs)
         return wrapper
     return decorator
 
 
-@_prepare_rng("random_state")
-def library_function(/, rng=None):
-    # The decorated library function takes an `rng` argument which is
-    # guaranteed to be a either a Generator or a RandomState.
-    # `random_state=` is supported input (the old can be customized).
+# Example usage of _prepare_rng decorator
+@_prepare_rng("random_state", 1, "1.15.0")
+def library_function(arg1, rng=None, arg2=None):
+    # The decorated library function accepts an `rng` argument, but the user
+    # can also pass a `random_state` argument (as specified by `old_name`) or
+    # a positional argument (with position specified by `position_name`). In
+    # any case, the argument passed to `library_function` will be either a
+    # Generator or a RandomState after validation by the decorator.
     assert isinstance(rng, (np.random.Generator, np.random.RandomState))
+    print((arg1, rng.random(), arg2))
 ```
 
 ### Core Project Endorsement
 
-<!--
-Discuss what it means for a core project to endorse this SPEC.
--->
+Endorsement of this SPEC means that a project intends to:
+
+- avoid the use of global state and legacy bitstream generators, and
+- standardize the usage and interpretation of an `rng` keyword for seeding.
 
 ### Ecosystem Adoption
 
-<!--
-Discuss what it means for a project to adopt this SPEC.
--->
+To adot this SPEC, a project should:
+
+- deprecate the use of `RandomState` and `numpy.random.seed`,
+- accept an `rng` argument in all functions that require random number generation, and
+- use `numpy.random.default_rng` to validate the `rng` argument and instantiate a `Generator`.
 
 ## Notes
 
-<!--
-Include a bulleted list of annotated links, comments,
-and other ancillary information as needed.
--->
+

--- a/spec-0007/index.md
+++ b/spec-0007/index.md
@@ -119,103 +119,42 @@ There are three classes of users, which will be affected to varying degrees.
 
 ### Code
 
-As an example, consider how a SciPy function would transition from a `random_state` parameter to the `rng` keyword using a decorator.
-This is implemented using:
-
-1. A `check_random_state` function which normalizes either old (`random_state`) or new (`rng`) input to a `Generator` object.
-   If `np.random.seed()` was called, and neither `random_state` nor `rng` is given, a `FutureWarning` is raised to let the user know that they _tried_ to set the seed but in the future it will have no effect.
-2. A decorator to handle renaming the `random_state` keyword to `rng`.
-   At a given future version, the decorator deprecates the keyword-only parameter `random_state`; for now, it provides the new `rng` keyword, so users can start switching in preparation.
-   It changes the documentation and auto-completion to only advertise the new `rng` parameter.
+As an example, consider how a SciPy function would transition from a `random_state` parameter to an `rng` parameter using a decorator.
 
 ```python
 import numpy as np
 import functools
-import numbers
 import warnings
 
-_NoValue = object()  # singleton to indicate not explicitly passed
-
-# Should this specify the version number in which the behavior will change?
-def _check_random_state(seed=_NoValue, rng=_NoValue):
-    """ PRNG validator during deprecation period
-    
-    Accepts inputs specified via old `seed`/`random_state` argument
-    and new `rng` argument and returns appropriate PRNG.
-    
-    Once the removal of `seed`/`random_state` argument is complete,
-    this function may be removed, and `numpy.random.default_rng` may be
-    used to validate the `rng` argument.
-    
-    Parameters
-    ----------
-    seed : <insert long list of objects here>
-        Input specified via old `seed`/`random_state` argument
-    rng :  <insert long list of objects here>
-        Input specified via new `rng` argument
-    Returns
-    -------
-    prng : NumPy `Generator` or `RandomState`
-        Pseudo-random number generator
-    """
-    if rng is not _NoValue and seed is not _NoValue:
-        raise TypeError("Cannot pass both `rng` and `seed`/`random_state`.")
-    if rng is not _NoValue:
-        return np.random.default_rng(rng)
-
-    if seed is _NoValue:
-        # If the user passed nothing, we have to reach into NumPy here:
-        # 1. If np.random.seed(None) was called (or never called), then we can
-        #    just use the default_rng (the result is random anyway).
-        # 2. If it was called, we must return the global random state object
-        #    and warn about future ignoring of seed!
-        if np.random.mtrand._rand._bit_generator._seed_seq is not None:
-            # The user did not seed, so no need to warn.
-            return np.random.default_rng()
-        warnings.warn(
-            "The NumPy global rng was seeded in call to np.random.seed() "
-            "in the future this function will ignore this seed and return "
-            "random values as if a new `np.random.default_rng()` was created.",
-            FutureWarning, stacklevel=5)
-        return np.random.mtrand._rand
-    if seed is None or seed is np.random:
-        return np.random.mtrand._rand
-    if isinstance(seed, (numbers.Integral, np.integer)):
-        return np.random.RandomState(seed)
-    if isinstance(seed, (np.random.RandomState, np.random.Generator)):
-        return seed
-
-    raise ValueError(f"'{seed}' cannot be used to seed a numpy.random.RandomState"
-                     " instance.")
-
-
-def _prepare_rng(old_name, position_num=None, dep_version=None):
-    """ Example decorator to deprecate old PRNG usage
+def _transition_to_rng(old_name, position_num=None, dep_version=None):
+    """ Example decorator to transition from old PRNG usage to new `rng` behavior
 
     Suppose the decorator is applied to a function that used to accept parameter
     `old_name='random_state'` either by keyword or as a positional argument at
     `position_name=1`. At the time of application, the name of the argument in the
     function signature is manually changed to the new name, `rng`.
+
     - If the function is called with both `random_state` and `rng`, the decorator
       raises an error.
-    - If `random_state` is provided as a keyword argument, the decorator validates
-      the argument according to the old rules* and passes it to the function as `rng`,
-      but the decorator will emit a warning about the deprecation of keyword 
-      `random_state`.
-    - If `random_state` is provided as a positional argument, the decorator validates
-      the argument according to the old rules* and passes it to the function as `rng`,
-      but the decorator will emit a warning about the deprecation of positional use of
-      `random_state` and all following arguments.
+    - If `random_state` is provided as a keyword argument, the decorator passes
+      `random_state` to the function's `rng` argument as a keyword, but the decorator
+      will emit a `DeprecationWarning` about the deprecation of keyword `random_state`.
+    - If `random_state` is provided as a positional argument, the decorator passes
+      `random_state` to the function's `rng` argument by position, but the decorator
+      will emit a `FutureWarning` about the changing behavior of the argument.
     - If `rng` is provided as a keyword argument, the decorator validates `rng` using
       `numpy.random.default_rng` before passing it to the function.
     - If neither `random_state` nor `rng` is provided, the decorator checks whether
-      `np.random.seed` has been used to set the global seed.
-      - If not, it passes a generator returned by `numpy.random.default_rng()` to the
-        function.
-      - If so, it passes the global `RandomState` to the function, but emits a
-        `FutureWarning` against use of `numpy.random.seed`.
-    To avoid warnings, a user must pass `rng` as a keyword, and the value must be
-    allowed by `numpy.random.default_rng`.
+      `np.random.seed` has been used to set the global seed. If so, it emits a
+      `FutureWarning` against use of `numpy.random.seed`. Either way, the decorator
+      calls the function without explicitly passing the `rng` argument.
+
+    To avoid warnings, a user must pass `rng` as a keyword or pass a `Generator`
+    object or `None` by position.
+
+    After the deprecation period, the decorator can be removed, and the function
+    can begin to validate the `rng` argument by calling `np.random.default_rng(rng)`
+    internally.
 
     Parameters
     ----------
@@ -226,9 +165,9 @@ def _prepare_rng(old_name, position_num=None, dep_version=None):
         Maintainers are welcome to eliminate this argument and use, for example,
         `inspect`, if preferred.
     dep_version : str, optional
-        The full version number of the library in which positional and kwarg use
-        of the old PRNG argument was deprecated. If specified, `DeprecationWarning`s
-        will be emitted.
+        The full version number of the library in which warnings about use of the
+        old PRNG argument begin to be emitted. The version in which the behavior
+        will change is assumed to be two versions later.
 
     """
     new_name = "rng"
@@ -246,38 +185,50 @@ def _prepare_rng(old_name, position_num=None, dep_version=None):
             as_new_kwarg = new_name in kwargs
             as_pos_arg = position_num is not None and len(args) >= position_num + 1
             
-            # Can only specify PRNG one way
+            # Can only specify PRNG one of the three ways
             if int(as_old_kwarg) + int(as_new_kwarg) + int(as_pos_arg) > 1:
                 message = (f"{fun.__name__}() got multiple values for "
                            f"argument now known as `{new_name}`")
                 raise TypeError(message)
-            
+
             if as_old_kwarg:  # warn about deprecated use of old kwarg
-                kwargs[new_name] = _check_random_state(seed=kwargs.pop(old_name))
+                kwargs[new_name] = kwargs.pop(old_name)
                 if dep_version:
                     message = (f"Use of keyword argument `{old_name}` is "
                                f"deprecated and replaced by `{new_name}`.  "
                                f"Support for `{old_name}` will be removed "
-                               f"in SciPy {end_version}.")
+                               f"in SciPy {end_version}. Use keyword `{new_name}` "
+                               "to silence this warning.")
                     warnings.warn(message, DeprecationWarning, stacklevel=2)
 
-            elif as_pos_arg:  # warn about deprecated positional use
-                # Not required for adoption of this SPEC; feel free to remove
-                args = list(args)
-                args[position_num] = _check_random_state(seed=args[position_num])
-                if dep_version:
-                    message = (f"Positional use of argument `{old_name}` and "
-                               "those that follow is deprecated and will cause "
-                               f"an error in SciPy {end_version}. Replace these "
-                               f"with keyword arguments, and use `{new_name}` "
-                               f"instead of `{old_name}`.")
-                    warnings.warn(message, DeprecationWarning, stacklevel=2)
+            elif as_pos_arg and dep_version:
+                # Warn about changing meaning of positional arg
+
+                # Note that this decorator does not deprecate positional use of the
+                # argument; it only warns that the behavior will change in the future.
+                # Simultaneously transitioning to keyword-only use is another option.
+
+                message = (f"Positional use of `{new_name}` (formerly known as "
+                           f"`{old_name}`) is still allowed, but the behavior is "
+                           "changing: the argument will be validated using "
+                           "`np.random.default_rng` beginning in SciPy {end_version} "
+                           f"Ensure that `np.random.default_rng(rng)` returns "
+                           "successfully to silence this warning.")
+                warnings.warn(message, FutureWarning, stacklevel=2)
 
             elif as_new_kwarg:  # no warnings; this is the preferred use
-                kwargs[new_name] = _check_random_state(rng=kwargs[new_name])
+                # After the removal of the decorator, validation with
+                # np.random.default_rng will be done inside the decorated function
+                kwargs[new_name] = np.random.default_rng(kwargs[new_name])
 
-            else:  # will emit FutureWarning if `np.random.seed` was used
-                kwargs[new_name] = _check_random_state()
+            elif np.random.mtrand._rand._bit_generator._seed_seq is None:
+                # Emit FutureWarning if `np.random.seed` was used and no PRNG was passed
+                message = ("The NumPy global rng was seeded by calling "
+                           f"`np.random.seed`. Beginning in {end_version}, this "
+                           "function will no longer use the global rng. It will "
+                           "instead use the `rng` argument, if provided, or create "
+                           "a new `Generator` using `np.random.default_rng()`.")
+                warnings.warn(message, FutureWarning, stacklevel=2)
 
             return fun(*args, **kwargs)
         return wrapper
@@ -285,23 +236,15 @@ def _prepare_rng(old_name, position_num=None, dep_version=None):
 
 
 # Example usage of _prepare_rng decorator
-@_prepare_rng("random_state", 1, "1.15.0")
-# previously, this function accepted `random_state` as the second argument
+@_transition_to_rng("random_state", 1, "1.15.0")
+# previously, the signature of the function was
+#   library_function(arg1, random_state=None, arg2=None):
 def library_function(arg1, rng=None, arg2=None):
-    # The decorated library function now accepts an `rng` argument, but the user
-    # can also pass a `random_state` argument (as specified by `old_name`) or
-    # a positional argument (with position specified by `position_name`). In
-    # any case, the argument passed to `library_function` will be either a
-    # `Generator` or a `RandomState` after validation by the decorator.
-    # After the deprecation period:
-    # - `rng` (and all following arguments) may be marked keyword-only,
-    # - the decorator can be removed, and
-    # - `rng = np.random.default_rng(rng)` can be used to validate `rng`
-    #   inside the function.
-    assert isinstance(rng, (np.random.Generator, np.random.RandomState))
-    print((arg1, rng.random(), arg2))
-```
+    if isinstance(rng, (np.random.Generator, np.random.RandomState)):
+        rng = rng.random()
+    print((arg1, rng, arg2))
 
+```
 ### Core Project Endorsement
 
 Endorsement of this SPEC means that a project intends to:

--- a/spec-0007/index.md
+++ b/spec-0007/index.md
@@ -102,7 +102,7 @@ The [deprecation strategy](https://github.com/scientific-python/specs/pull/180#i
 
    ```
 
-   Also note the suggested language for the `rng` parameter docstring, which encourages the user to pass a `Generator` or None, but allows for other types accepted by `numpy.random.default_rng`.
+   Also note the suggested language for the `rng` parameter docstring, which encourages the user to pass a `Generator` or None, but allows for other types accepted by `numpy.random.default_rng` (captured by the type annotation).
 
 ### Impact
 

--- a/spec-0007/index.md
+++ b/spec-0007/index.md
@@ -28,6 +28,8 @@ We suggest implementing these principles by:
 - deprecating the use of `random_state`/`seed` arguments in favor of a consistent `rng` argument, and
 - using `numpy.random.default_rng` to validate the `rng` argument and instantiate a `Generator`.
 
+Note that `numpy.random.default_rng` does not accept instances of `RandomState`, so use of `RandomState` to control the seed is effectively deprecated, too.
+
 ### Scope
 
 This is intended as a recommendation to all libraries that allow users to control the
@@ -35,7 +37,7 @@ state of a NumPy random number generator. It is specifically targeted toward fun
 that allow use of `numpy.random.seed` to control the random state and accept
 `RandomState` instances via an argument with a name other than `rng`, but the ideas
 are more broadly applicable. Use of random number generators other than those provided
-by NumPy are not considered at this time, but may be addressed in a future version.
+by NumPy are beyond the scope of this SPEC.
 
 ### Concepts
 
@@ -55,8 +57,8 @@ Legacy behavior in packages such as scikit-learn (`sklearn.utils.check_random_st
 
 Two strong motivations for moving over to `Generator`s are:
 
-(1) they avoid naïve seeding strategies, such as using successive integers, via the underlying [SeedSequence](https://numpy.org/doc/stable/reference/random/parallel.html#seedsequence-spawning);
-(2) they avoid using global state (from `numpy.random.mtrand._rand`).
+1. they avoid naïve seeding strategies, such as using successive integers, via the underlying [SeedSequence](https://numpy.org/doc/stable/reference/random/parallel.html#seedsequence-spawning);
+2. they avoid using global state (from `numpy.random.mtrand._rand`).
 
 Our recommendation here is a deprecation strategy which does not in _all_ cases adhere to the Hinsen[^hinsen] principle.
 
@@ -110,7 +112,7 @@ There are three classes of users, which will be affected to varying degrees.
 
 1. Those who do not attempt to control the random state.
    Their code will immediately switch from using the unseeded global `RandomState` to using an unseeded `Generator`.
-   Since the underlying _distributions_ of pseudo-random numbers will not change, these users will be relatively unaffected.
+   Since the underlying _distributions_ of pseudo-random numbers will not change, these users should be unaffected.
 
 2. Users of `random_state`/`seed` arguments.
    Support for these arguments will be dropped eventually, but during the deprecation period, we can provide clear guidance, via warnings and documentation, on how to migrate to the new `rng` keyword.

--- a/spec-0007/index.md
+++ b/spec-0007/index.md
@@ -66,8 +66,10 @@ The [deprecation strategy](https://github.com/scientific-python/specs/pull/180#i
 2. If both are specified, raise an error.
 3. If neither is specified and `np.random.seed` has been used to set the seed, emit a `FutureWarning` about the upcoming change in behavior.
 4. If `random_state`/`seed` is passed by keyword or by position, treat it as before, but:
-  - Emit a `DeprecationWarning` if passed by keyword, warning about the deprecation of keyword `random_state` in favor of `rng`.
-  - Emit a `FutureWarning` if passed by position, warning about the change in behavior of the positional argument.
+
+- Emit a `DeprecationWarning` if passed by keyword, warning about the deprecation of keyword `random_state` in favor of `rng`.
+- Emit a `FutureWarning` if passed by position, warning about the change in behavior of the positional argument.
+
 5. If `rng` is passed by keyword, standardize it using `numpy.random.default_rng`.
 6. After the deprecation period, use only `rng`, validated with `numpy.random.default_rng`.
    Raise an error if `random_state`/`seed` is provided.
@@ -110,10 +112,10 @@ There are three classes of users, which will be affected to varying degrees.
    Their code will immediately switch from using the unseeded global `RandomState` to using an unseeded `Generator`.
    Since the underlying _distributions_ of pseudo-random numbers will not change, these users will be relatively unaffected.
 
-2. Users of `random_state`/`seed` arguments. 
+2. Users of `random_state`/`seed` arguments.
    Support for these arguments will be dropped eventually, but during the deprecation period, we can provide clear guidance, via warnings and documentation, on how to migrate to the new `rng` keyword.
 
-3. Those who use `numpy.random.seed`. 
+3. Those who use `numpy.random.seed`.
    The proposal will do away with that global seeding mechanism, meaning that code that relies on it would, after the deprecation period, go from being seeded to being unseeded.
    To ensure that this does not go unnoticed, libraries that allowed for control of the random state via `numpy.random.seed` should raise a `FutureWarning` if `np.random.seed` has been called. (See Code below for an example.)
    In response, users must switch from using `numpy.random.seed` to passing the `rng` argument explicitly to all functions that accept it.
@@ -124,130 +126,8 @@ There are three classes of users, which will be affected to varying degrees.
 
 As an example, consider how a SciPy function would transition from a `random_state` parameter to an `rng` parameter using a decorator.
 
-```python
-import numpy as np
-import functools
-import warnings
+{{< include-code "transition_to_rng.py" "python" >}}
 
-def _transition_to_rng(old_name, position_num=None, dep_version=None):
-    """ Example decorator to transition from old PRNG usage to new `rng` behavior
-
-    Suppose the decorator is applied to a function that used to accept parameter
-    `old_name='random_state'` either by keyword or as a positional argument at
-    `position_name=1`. At the time of application, the name of the argument in the
-    function signature is manually changed to the new name, `rng`.
-
-    - If the function is called with both `random_state` and `rng`, the decorator
-      raises an error.
-    - If `random_state` is provided as a keyword argument, the decorator passes
-      `random_state` to the function's `rng` argument as a keyword, but the decorator
-      will emit a `DeprecationWarning` about the deprecation of keyword `random_state`.
-    - If `random_state` is provided as a positional argument, the decorator passes
-      `random_state` to the function's `rng` argument by position, but the decorator
-      will emit a `FutureWarning` about the changing behavior of the argument.
-    - If `rng` is provided as a keyword argument, the decorator validates `rng` using
-      `numpy.random.default_rng` before passing it to the function.
-    - If neither `random_state` nor `rng` is provided, the decorator checks whether
-      `np.random.seed` has been used to set the global seed. If so, it emits a
-      `FutureWarning` against use of `numpy.random.seed`. Either way, the decorator
-      calls the function without explicitly passing the `rng` argument.
-
-    To avoid warnings, a user must pass `rng` as a keyword or pass a `Generator`
-    object or `None` by position.
-
-    After the deprecation period, the decorator can be removed, and the function
-    can begin to validate the `rng` argument by calling `np.random.default_rng(rng)`
-    internally.
-
-    Parameters
-    ----------
-    old_name : str
-        The old name of the PRNG argument (e.g. `seed` or `random_state`).
-    position_num : int, optional
-        The (0-indexed) position of the old PRNG argument (if accepted by position).
-        Maintainers are welcome to eliminate this argument and use, for example,
-        `inspect`, if preferred.
-    dep_version : str, optional
-        The full version number of the library in which warnings about use of the
-        old PRNG argument begin to be emitted. The version in which the behavior
-        will change is assumed to be two versions later.
-
-    """
-    new_name = "rng"
-
-    if dep_version:
-        end_version = dep_version.split('.')
-        end_version[1] = str(int(end_version[1]) + 2)
-        end_version = '.'.join(end_version)
-
-    def decorator(fun):
-        @functools.wraps(fun)
-        def wrapper(*args, **kwargs):
-            # Determine how PRNG was passed
-            as_old_kwarg = old_name in kwargs
-            as_new_kwarg = new_name in kwargs
-            as_pos_arg = position_num is not None and len(args) >= position_num + 1
-            
-            # Can only specify PRNG one of the three ways
-            if int(as_old_kwarg) + int(as_new_kwarg) + int(as_pos_arg) > 1:
-                message = (f"{fun.__name__}() got multiple values for "
-                           f"argument now known as `{new_name}`")
-                raise TypeError(message)
-
-            if as_old_kwarg:  # warn about deprecated use of old kwarg
-                kwargs[new_name] = kwargs.pop(old_name)
-                if dep_version:
-                    message = (f"Use of keyword argument `{old_name}` is "
-                               f"deprecated and replaced by `{new_name}`.  "
-                               f"Support for `{old_name}` will be removed "
-                               f"in SciPy {end_version}. Use keyword `{new_name}` "
-                               "to silence this warning.")
-                    warnings.warn(message, DeprecationWarning, stacklevel=2)
-
-            elif as_pos_arg and dep_version:
-                # Warn about changing meaning of positional arg
-
-                # Note that this decorator does not deprecate positional use of the
-                # argument; it only warns that the behavior will change in the future.
-                # Simultaneously transitioning to keyword-only use is another option.
-
-                message = (f"Positional use of `{new_name}` (formerly known as "
-                           f"`{old_name}`) is still allowed, but the behavior is "
-                           "changing: the argument will be validated using "
-                           "`np.random.default_rng` beginning in SciPy {end_version} "
-                           f"Ensure that `np.random.default_rng(rng)` returns "
-                           "successfully to silence this warning.")
-                warnings.warn(message, FutureWarning, stacklevel=2)
-
-            elif as_new_kwarg:  # no warnings; this is the preferred use
-                # After the removal of the decorator, validation with
-                # np.random.default_rng will be done inside the decorated function
-                kwargs[new_name] = np.random.default_rng(kwargs[new_name])
-
-            elif np.random.mtrand._rand._bit_generator._seed_seq is None:
-                # Emit FutureWarning if `np.random.seed` was used and no PRNG was passed
-                message = ("The NumPy global rng was seeded by calling "
-                           f"`np.random.seed`. Beginning in {end_version}, this "
-                           "function will no longer use the global rng. It will "
-                           "instead use the `rng` argument, if provided, or create "
-                           "a new `Generator` using `np.random.default_rng()`.")
-                warnings.warn(message, FutureWarning, stacklevel=2)
-
-            return fun(*args, **kwargs)
-        return wrapper
-    return decorator
-
-
-# Example usage of _prepare_rng decorator
-@_transition_to_rng("random_state", 1, "1.15.0")
-# previously, the signature of the function was
-#   library_function(arg1, random_state=None, arg2=None):
-def library_function(arg1, rng=None, arg2=None):
-    if isinstance(rng, (np.random.Generator, np.random.RandomState)):
-        rng = rng.random()
-    print((arg1, rng, arg2))
-
-```
 ### Core Project Endorsement
 
 Endorsement of this SPEC means that a project intends to:
@@ -264,5 +144,3 @@ To adopt this SPEC, a project should:
 - use `numpy.random.default_rng` to validate the `rng` argument and instantiate a `Generator`.
 
 ## Notes
-
-

--- a/spec-0007/transition_to_rng.py
+++ b/spec-0007/transition_to_rng.py
@@ -1,0 +1,132 @@
+import numpy as np
+import functools
+import warnings
+
+
+def _transition_to_rng(old_name, position_num=None, dep_version=None):
+    """Example decorator to transition from old PRNG usage to new `rng` behavior
+
+    Suppose the decorator is applied to a function that used to accept parameter
+    `old_name='random_state'` either by keyword or as a positional argument at
+    `position_name=1`. At the time of application, the name of the argument in the
+    function signature is manually changed to the new name, `rng`.
+
+    - If the function is called with both `random_state` and `rng`, the decorator
+      raises an error.
+    - If `random_state` is provided as a keyword argument, the decorator passes
+      `random_state` to the function's `rng` argument as a keyword, but the decorator
+      will emit a `DeprecationWarning` about the deprecation of keyword `random_state`.
+    - If `random_state` is provided as a positional argument, the decorator passes
+      `random_state` to the function's `rng` argument by position, but the decorator
+      will emit a `FutureWarning` about the changing behavior of the argument.
+    - If `rng` is provided as a keyword argument, the decorator validates `rng` using
+      `numpy.random.default_rng` before passing it to the function.
+    - If neither `random_state` nor `rng` is provided, the decorator checks whether
+      `np.random.seed` has been used to set the global seed. If so, it emits a
+      `FutureWarning` against use of `numpy.random.seed`. Either way, the decorator
+      calls the function without explicitly passing the `rng` argument.
+
+    To avoid warnings, a user must pass `rng` as a keyword or pass a `Generator`
+    object or `None` by position.
+
+    After the deprecation period, the decorator can be removed, and the function
+    can begin to validate the `rng` argument by calling `np.random.default_rng(rng)`
+    internally.
+
+    Parameters
+    ----------
+    old_name : str
+        The old name of the PRNG argument (e.g. `seed` or `random_state`).
+    position_num : int, optional
+        The (0-indexed) position of the old PRNG argument (if accepted by position).
+        Maintainers are welcome to eliminate this argument and use, for example,
+        `inspect`, if preferred.
+    dep_version : str, optional
+        The full version number of the library in which warnings about use of the
+        old PRNG argument begin to be emitted. The version in which the behavior
+        will change is assumed to be two versions later.
+
+    """
+    new_name = "rng"
+
+    if dep_version:
+        end_version = dep_version.split(".")
+        end_version[1] = str(int(end_version[1]) + 2)
+        end_version = ".".join(end_version)
+
+    def decorator(fun):
+        @functools.wraps(fun)
+        def wrapper(*args, **kwargs):
+            # Determine how PRNG was passed
+            as_old_kwarg = old_name in kwargs
+            as_new_kwarg = new_name in kwargs
+            as_pos_arg = position_num is not None and len(args) >= position_num + 1
+
+            # Can only specify PRNG one of the three ways
+            if int(as_old_kwarg) + int(as_new_kwarg) + int(as_pos_arg) > 1:
+                message = (
+                    f"{fun.__name__}() got multiple values for "
+                    f"argument now known as `{new_name}`"
+                )
+                raise TypeError(message)
+
+            if as_old_kwarg:  # warn about deprecated use of old kwarg
+                kwargs[new_name] = kwargs.pop(old_name)
+                if dep_version:
+                    message = (
+                        f"Use of keyword argument `{old_name}` is "
+                        f"deprecated and replaced by `{new_name}`.  "
+                        f"Support for `{old_name}` will be removed "
+                        f"in SciPy {end_version}. Use keyword `{new_name}` "
+                        "to silence this warning."
+                    )
+                    warnings.warn(message, DeprecationWarning, stacklevel=2)
+
+            elif as_pos_arg and dep_version:
+                # Warn about changing meaning of positional arg
+
+                # Note that this decorator does not deprecate positional use of the
+                # argument; it only warns that the behavior will change in the future.
+                # Simultaneously transitioning to keyword-only use is another option.
+
+                message = (
+                    f"Positional use of `{new_name}` (formerly known as "
+                    f"`{old_name}`) is still allowed, but the behavior is "
+                    "changing: the argument will be validated using "
+                    "`np.random.default_rng` beginning in SciPy {end_version} "
+                    f"Ensure that `np.random.default_rng(rng)` returns "
+                    "successfully to silence this warning."
+                )
+                warnings.warn(message, FutureWarning, stacklevel=2)
+
+            elif as_new_kwarg:  # no warnings; this is the preferred use
+                # After the removal of the decorator, validation with
+                # np.random.default_rng will be done inside the decorated function
+                kwargs[new_name] = np.random.default_rng(kwargs[new_name])
+
+            elif np.random.mtrand._rand._bit_generator._seed_seq is None:
+                # Emit FutureWarning if `np.random.seed` was used and no PRNG was passed
+                message = (
+                    "The NumPy global rng was seeded by calling "
+                    f"`np.random.seed`. Beginning in {end_version}, this "
+                    "function will no longer use the global rng. It will "
+                    "instead use the `rng` argument, if provided, or create "
+                    "a new `Generator` using `np.random.default_rng()`."
+                )
+                warnings.warn(message, FutureWarning, stacklevel=2)
+
+            return fun(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+# Example usage of _prepare_rng decorator
+@_transition_to_rng("random_state", 1, "1.15.0")
+# previously, the signature of the function was
+#   library_function(arg1, random_state=None, arg2=None):
+def library_function(arg1, rng=None, arg2=None):
+    if isinstance(rng, (np.random.Generator, np.random.RandomState)):
+        rng = rng.random()
+    print((arg1, rng, arg2))

--- a/spec-0007/transition_to_rng.py
+++ b/spec-0007/transition_to_rng.py
@@ -81,15 +81,16 @@ def _transition_to_rng(old_name, position_num=None, dep_version=None):
                            f"argument now known as `{new_name}`")
                 raise TypeError(message)
 
-            cmn_msg = ("To silence this warning and ensure consistent behavior in "
+            cmn_msg = (" To silence this warning and ensure consistent behavior in "
                        f"SciPy {end_version}, control the RNG using argument "
-                       f"{new_name}. Arguments passed to keyword {new_name} will be "
-                       "validated by `np.random.default_rng`, so the behavior "
+                       f"`{new_name}`. Arguments passed to keyword `{new_name}` will "
+                       "be validated by `np.random.default_rng`, so the behavior "
                        "corresponding with a given value may change compared to use "
                        f"of {old_name}. For example, "
-                       "1) `None` produces unpredictable random numbers, "
-                       "2) integer produces a different stream of random numbers, and "
-                       "3) `np.random` or `RandomState` instance raises an error. "
+                       "1) `None` results in unpredictable random numbers, "
+                       "2) an integer results in a different stream of random numbers,
+                       "(with the same distribution), and "
+                       "3) `np.random` or `RandomState` instances result in an error. "
                        "See the documentation of `default_rng` for more information.")
 
             if as_old_kwarg:  # warn about deprecated use of old kwarg
@@ -111,7 +112,7 @@ def _transition_to_rng(old_name, position_num=None, dep_version=None):
                 message = (f"Positional use of `{new_name}` (formerly known as "
                            f"`{old_name}`) is still allowed, but the behavior is "
                            "changing: the argument will be validated using "
-                           f"`np.random.default_rng` beginning in SciPy {end_version} "
+                           f"`np.random.default_rng` beginning in SciPy {end_version}."
                            ) + cmn_msg
                 warnings.warn(message, FutureWarning, stacklevel=2)
 

--- a/spec-0007/transition_to_rng.py
+++ b/spec-0007/transition_to_rng.py
@@ -86,7 +86,7 @@ def _transition_to_rng(old_name, position_num=None, dep_version=None):
                        f"`{new_name}`. Arguments passed to keyword `{new_name}` will "
                        "be validated by `np.random.default_rng`, so the behavior "
                        "corresponding with a given value may change compared to use "
-                       f"of {old_name}. For example, "
+                       f"of `{old_name}`. For example, "
                        "1) `None` results in unpredictable random numbers, "
                        "2) an integer results in a different stream of random numbers,
                        "(with the same distribution), and "


### PR DESCRIPTION
Not quite done, but wanted to get something up.

To do:
- [ ] Test decorator comprehensively. This has to "just work".
- [x] Mention that this only applies to NumPy PRNGs; consideration of other PRNGs deserves consideration but is currently out of scope for this SPEC.

<details>
Some sample code for `library_function`. Should write a comprehensive parameterized, property-based test.

```python3
library_function(1)  # (1, <random>, None)
library_function(1)  # (1, <random>, None)

library_function(1, 1)  # (1, 0.417022004702574, None), warns positional `random_state`
library_function(1, 1)  # (1, 0.417022004702574, None), warns positional `random_state`

library_function(1, random_state=1)  # (1, 0.417022004702574, None), warns kwarg `random_state`
library_function(1, random_state=1)  # (1, 0.417022004702574, None), warns kwarg `random_state`

library_function(1, rng=1)  # (1, 0.5118216247002567, None)
library_function(1, rng=1)  # (1, 0.5118216247002567, None)

library_function(1, np.random.RandomState(1))  # (1, 0.417022004702574, None), warns positional `random_state`
library_function(1, random_state=np.random.RandomState(1))  # (1, 0.417022004702574, None), warns kwarg `random_state`
library_function(1, rng=np.random.RandomState(1))  # (1, 0.5118216247002567, None)

library_function(1, None)  # (1, 0.417022004702574, None), warns positional `random_state`
library_function(1, None)  # (1, 0.417022004702574, None), warns positional `random_state`

library_function(1, random_state=None)  # (1, 0.417022004702574, None), warns kwarg `random_state`
library_function(1, random_state=None)  # (1, 0.417022004702574, None), warns kwarg `random_state`

library_function(1, rng=None)  # (1, 0.5118216247002567, None)
library_function(1, rng=None)  # (1, 0.5118216247002567, None)

np.random.seed(0)
library_function(1)  # (1, 0.5488135039273248, None), FutureWarning
np.random.seed(0)
library_function(1, None)  # (1, 0.5448831829968969, None), warns positional `random_state`
np.random.seed(0)
library_function(1, random_state=None)  # (1, 0.5448831829968969, None), warns kwarg `random_state`
np.random.seed(0)
library_function(1, rng=None)  # (1, <random>, None)
```
</details>