### PR TITLE
Adjustments to SPEC7 per recent reviews

### DIFF
--- a/spec-0007/index.md
+++ b/spec-0007/index.md
@@ -24,11 +24,12 @@ We recommend:
 
 We suggest implementing these principles by:
 
-- deprecating the use of `numpy.random.seed` to control the random state,
+- deprecating user control of downstream library behavior with `numpy.random.seed`,
 - deprecating the use of `random_state`/`seed` arguments in favor of a consistent `rng` argument, and
 - using `numpy.random.default_rng` to validate the `rng` argument and instantiate a `Generator`.
 
-Note that `numpy.random.default_rng` does not accept instances of `RandomState`, so use of `RandomState` to control the seed is effectively deprecated, too.
+Note that `numpy.random.default_rng` does not accept instances of `RandomState`, so user control of library behavior with instances of `RandomState` is effectively deprecated, too.
+That said, neither `np.random.seed` nor `np.random.RandomState` themselves are deprecated, so they may still be used in some contexts (e.g. by developers for generating unit test data).
 
 ### Scope
 

--- a/spec-0007/index.md
+++ b/spec-0007/index.md
@@ -24,11 +24,11 @@ We recommend:
 
 We suggest implementing these principles by:
 
-- deprecating user control of downstream library behavior with `numpy.random.seed`,
+- deprecating the use of `numpy.random.seed` to control the random state,
 - deprecating the use of `random_state`/`seed` arguments in favor of a consistent `rng` argument, and
 - using `numpy.random.default_rng` to validate the `rng` argument and instantiate a `Generator`.
 
-Note that `numpy.random.default_rng` does not accept instances of `RandomState`, so user control of library behavior with instances of `RandomState` is effectively deprecated, too.
+Note that `numpy.random.default_rng` does not accept instances of `RandomState`, so use of `RandomState` to control the seed is effectively deprecated, too.
 That said, neither `np.random.seed` nor `np.random.RandomState` themselves are deprecated, so they may still be used in some contexts (e.g. by developers for generating unit test data).
 
 ## Motivation

--- a/spec-0007/index.md
+++ b/spec-0007/index.md
@@ -65,21 +65,26 @@ although it could very nearly do so by enforcing the use of `rng` as a keyword a
 
 [^hinsen]: The Hinsen principle states, loosely, that code should, whether executed now or in the future, return the same result, or raise an error.
 
-The [deprecation strategy](https://github.com/scientific-python/specs/pull/180#issuecomment-1515248009) is:
+The [deprecation strategy](https://github.com/scientific-python/specs/pull/180#issuecomment-1515248009) is as follows.
 
-1. Accept both `rng` and `random_state`/`seed` keyword arguments.
-2. If both are specified, raise an error.
-3. If neither is specified and `np.random.seed` has been used to set the seed, emit a `FutureWarning` about the upcoming change in behavior.
-4. If `random_state`/`seed` is passed by keyword or by position, treat it as before, but:
+Initially:
+
+- Accept both `rng` and `random_state`/`seed` keyword arguments.
+- If both are specified by the user, raise an error.
+- If `rng` is passed by keyword, validate it with `np.random.default_rng()` and use it to generate random numbers as needed.
+- If `random_state`/`seed` is specified (by keyword or position, if allowed), preserve existing behavior.
+
+After `rng` is available in all releases within the support window suggested by SPEC 0, emit warnings as follows.
+
+- If neither `rng` nor `random_state`/`seed` is specified and `np.random.seed` has been used to set the seed, emit a `FutureWarning` about the upcoming change in behavior.
+- If `random_state`/`seed` is passed by keyword or by position, treat it as before, but:
 
    - Emit a `DeprecationWarning` if passed by keyword, warning about the deprecation of keyword `random_state` in favor of `rng`.
    - Emit a `FutureWarning` if passed by position, warning about the change in behavior of the positional argument.
 
-5. If `rng` is passed by keyword, standardize it using `numpy.random.default_rng`.
-6. After the deprecation period, use only `rng`, validated with `numpy.random.default_rng`.
-   Raise an error if `random_state`/`seed` is provided.
+After the deprecation period, accept only `rng`, raising an error if `random_state`/`seed` is provided.
 
-   By now, the function signature, with type annotations, could look like this:
+By now, the function signature, with type annotations, could look like this:
 
    ```python
    from collections.abc import Sequence

--- a/spec-0007/index.md
+++ b/spec-0007/index.md
@@ -31,6 +31,13 @@ We suggest implementing these principles by:
 Note that `numpy.random.default_rng` does not accept instances of `RandomState`, so user control of library behavior with instances of `RandomState` is effectively deprecated, too.
 That said, neither `np.random.seed` nor `np.random.RandomState` themselves are deprecated, so they may still be used in some contexts (e.g. by developers for generating unit test data).
 
+## Motivation
+
+Two strong motivations for moving over to `Generator`s are:
+
+1. they avoid naïve seeding strategies, such as using successive integers, via the underlying [SeedSequence](https://numpy.org/doc/stable/reference/random/parallel.html#seedsequence-spawning);
+2. they avoid using global state (from `numpy.random.mtrand._rand`).
+
 ### Scope
 
 This is intended as a recommendation to all libraries that allow users to control the
@@ -55,11 +62,6 @@ In practice, the seed is unfortunately also often controlled using `numpy.random
 ## Implementation
 
 Legacy behavior in packages such as scikit-learn (`sklearn.utils.check_random_state`) typically handle `None` (use the global seed state), an int (convert to `RandomState`), or `RandomState` object.
-
-Two strong motivations for moving over to `Generator`s are:
-
-1. they avoid naïve seeding strategies, such as using successive integers, via the underlying [SeedSequence](https://numpy.org/doc/stable/reference/random/parallel.html#seedsequence-spawning);
-2. they avoid using global state (from `numpy.random.mtrand._rand`).
 
 Our recommendation here is a deprecation strategy which does not in _all_ cases adhere to the Hinsen principle[^hinsen],
 although it could very nearly do so by enforcing the use of `rng` as a keyword argument.

--- a/spec-0007/test_transition_to_rng.py
+++ b/spec-0007/test_transition_to_rng.py
@@ -35,10 +35,16 @@ def test_seeded_vs_unseeded():
 
 
 def test_positional_random_state():
+    # doesn't need to warn
+    library_function(1, None)  # seed not set
+    library_function(1, np.random.default_rng(2384924))  # Generators still accepted
+
     with pytest.warns(FutureWarning, match="Positional use of"):
-        library_function(1, None)
-        library_function(1, 1)
+        library_function(1, 1)  # behavior will change
+
+        # will raise error in the future
         library_function(1, np.random.RandomState(1))
+        library_function(1, np.random)
 
 
 def test_random_state_deprecated():

--- a/spec-0007/test_transition_to_rng.py
+++ b/spec-0007/test_transition_to_rng.py
@@ -66,7 +66,7 @@ def test_rng_incorrect_usage():
         library_function(1, rng=1, random_state=1)
 
 
-@_transition_to_rng("random_state", dep_version="1.15.0")
+@_transition_to_rng("random_state", end_version="1.17.0")
 # previously, the signature of the function was
 #   library_function(arg1, random_state=None, arg2=None):
 def random_function(arg1, *, rng=None, arg2=None):

--- a/spec-0007/transition_to_rng.py
+++ b/spec-0007/transition_to_rng.py
@@ -38,9 +38,11 @@ def _transition_to_rng(old_name, *, position_num=None, end_version):
       code yielding different results in two versions of the software)
       will be violated, unless positional use is deprecated. Specifically:
 
-      - If `None` is passed by position, the function will change from being
-        seeded to being unseeded.
+      - If `None` is passed by position and `np.random.seed` has been used,
+        the function will change from being seeded to being unseeded.
       - If an integer is passed by position, the random stream will change.
+      - If `np.random` or an instance of `RandomState` is passed by position,
+        an error will be raised.
 
       We suggest that projects consider deprecating positional use of
       `random_state`/`rng` (i.e., change their function signatures to

--- a/spec-0007/transition_to_rng.py
+++ b/spec-0007/transition_to_rng.py
@@ -113,13 +113,23 @@ def _transition_to_rng(old_name, *, position_num=None, end_version):
                 # argument; it only warns that the behavior will change in the future.
                 # Simultaneously transitioning to keyword-only use is another option.
 
-                message = (
-                    f"Positional use of `{NEW_NAME}` (formerly known as "
-                    f"`{old_name}`) is still allowed, but the behavior is "
-                    "changing: the argument will be validated using "
-                    f"`np.random.default_rng` beginning in SciPy {end_version}."
-                ) + cmn_msg
-                warnings.warn(message, FutureWarning, stacklevel=2)
+                arg = args[position_num]
+                # If the argument is None and the global seed wasn't set, or if the
+                # argument is one of a few new classes, the user will not notice change
+                # in behavior.
+                ok_classes = (np.random.Generator,
+                              np.random.SeedSequence,
+                              np.random.BitGenerator)
+                if (arg is None and not global_seed_set) or isinstance(arg, ok_classes):
+                    pass
+                else:
+                    message = (
+                        f"Positional use of `{NEW_NAME}` (formerly known as "
+                        f"`{old_name}`) is still allowed, but the behavior is "
+                        "changing: the argument will be validated using "
+                        f"`np.random.default_rng` beginning in SciPy {end_version}."
+                    ) + cmn_msg
+                    warnings.warn(message, FutureWarning, stacklevel=2)
 
             elif as_new_kwarg:  # no warnings; this is the preferred use
                 # After the removal of the decorator, validation with

--- a/spec-0007/transition_to_rng.py
+++ b/spec-0007/transition_to_rng.py
@@ -68,6 +68,19 @@ def _transition_to_rng(old_name, *, position_num=None, end_version=None):
     """
     NEW_NAME = "rng"
 
+    cmn_msg = (
+        "To silence this warning and ensure consistent behavior in SciPy "
+        f"{end_version}, control the RNG using argument `{NEW_NAME}`. Arguments passed "
+        f"to keyword `{NEW_NAME}` will be validated by `np.random.default_rng`, so the "
+        "behavior corresponding with a given value may change compared to use of "
+        f"`{old_name}`. For example, "
+        "1) `None` will result in unpredictable random numbers, "
+        "2) an integer will result in a different stream of random numbers, (with the "
+        "same distribution), and "
+        "3) `np.random` or `RandomState` instances will result in an error. "
+        "See the documentation of `default_rng` for more information."
+    )
+
     def decorator(fun):
         @functools.wraps(fun)
         def wrapper(*args, **kwargs):
@@ -84,20 +97,6 @@ def _transition_to_rng(old_name, *, position_num=None, end_version=None):
                     f"argument now known as `{NEW_NAME}`"
                 )
                 raise TypeError(message)
-
-            cmn_msg = (
-                " To silence this warning and ensure consistent behavior in "
-                f"SciPy {end_version}, control the RNG using argument "
-                f"`{NEW_NAME}`. Arguments passed to keyword `{NEW_NAME}` will "
-                "be validated by `np.random.default_rng`, so the behavior "
-                "corresponding with a given value may change compared to use "
-                f"of `{old_name}`. For example, "
-                "1) `None` results in unpredictable random numbers, "
-                "2) an integer results in a different stream of random numbers, "
-                "(with the same distribution), and "
-                "3) `np.random` or `RandomState` instances result in an error. "
-                "See the documentation of `default_rng` for more information."
-            )
 
             # Check whether global random state has been set
             global_seed_set = np.random.mtrand._rand._bit_generator._seed_seq is None


### PR DESCRIPTION
Re: scientific-python/specs#180:

~~27934c76bc0a13554da218f71095d2a776f4299d addresses https://github.com/scientific-python/specs/pull/180#discussion_r1681572826. It also makes `end_version` a required argument. I don't think the decorator needs to allow the possibility of adding `rng` without emitting warnings in some cases, and there was a bug because we didn't always check whether the version was specified or not.~~ This was effectively reversed due to https://github.com/scientific-python/specs/pull/180#discussion_r1705103987.

636bc5d1c128b94dfefe9014882adade63b570d3 addresses https://github.com/scientific-python/specs/pull/180#discussion_r1684414274.

bd32f7b3377fb499e5e6da9b35db1e049debbc83 addresses https://github.com/scientific-python/specs/pull/180#discussion_r1684418861.

6ec3b6ae1dd5ccc012eb16b5d2c218194c9120fa addresses https://github.com/scientific-python/specs/pull/180#discussion_r1705103987

4aa7051ee73a82bb676ddfab1d4aa310c1f9267e addresses https://github.com/scientific-python/specs/pull/180#discussion_r1703231046

37ff883a4b5bd3272e5aea3ce75ab36f851ac8ce addresses https://github.com/scientific-python/specs/pull/180#discussion_r1705059940

2dcf128f3817f614ae76e7749eda5b26d7b486fb partially addresses https://github.com/scientific-python/specs/pull/180#discussion_r1705091496, but the main comment was to add more motivation. Please extend with other motivation after this PR merges.

cc43293281956828f2953e54952480de8d15d533 addresses https://github.com/scientific-python/specs/pull/180#discussion_r1703240334

7b4c61b0b0a6e20cc7c6a22fb28808a41885d9b6 addresses https://github.com/scientific-python/specs/pull/180#discussion_r1703224726


